### PR TITLE
🚧 Created optimistic version that does not block the bridge

### DIFF
--- a/src/OptimisticCCCB/SourceChainOptimisticCCCB.sol
+++ b/src/OptimisticCCCB/SourceChainOptimisticCCCB.sol
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: Apache License 2.0
+pragma solidity 0.8.20;
+
+import {ISourceChainOptimisticCCCB} from "../interfaces/OptimisticCCCB/ISourceChainOptimisticCCCB.sol";
+import {Client} from "@chainlink/contracts-ccip/src/v0.8/ccip/libraries/Client.sol";
+import {IRouterClient} from "@chainlink/contracts-ccip/src/v0.8/ccip/interfaces/IRouterClient.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Withdraw} from "../utils/Withdraw.sol";
+import {TaxManager} from "../TaxManager.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+contract SourceChainOptimisticCCCB is ISourceChainOptimisticCCCB, TaxManager {
+    using SafeERC20 for IERC20;
+
+    address public tokenAddress;
+    uint64 public destinationChainSelector;
+    address public destinationContract;
+    uint256 public destinationGasLimit;
+    address public localRouter;
+
+    uint256 currentRoundId;
+    FullRound[] public rounds;
+
+    constructor(
+        address _router,
+        uint64 _destinationChainSelector,
+        uint64 _currentChainSelector,
+        address _owner,
+        address _tokenAddress,
+        address _localRouter
+    ) TaxManager(_currentChainSelector, _owner) {
+        destinationChainSelector = _destinationChainSelector;
+        currentRoundId = 0;
+        tokenAddress = _tokenAddress;
+        destinationGasLimit = 2_000_000;
+        localRouter = _localRouter;
+        
+        FullRound storage newRound = rounds.push();
+        newRound.roundId = 0;
+        newRound.participants = new address[](0);
+
+        IERC20(tokenAddress).approve(address(_router), type(uint256).max);
+    }
+
+    receive() external payable {}
+
+    /**
+     * Setter to use just after contract deployment
+     */
+
+    function setTokenAddress(address _tokenAddress) external onlyOwner {
+        tokenAddress = _tokenAddress;
+    }
+
+    function setDestinationContract(address _destinationContract) external onlyOwner {
+        destinationContract = _destinationContract;
+    }
+
+    function setDestinationGasLimit(uint256 _destinationGasLimit) external onlyOwner {
+        destinationGasLimit = _destinationGasLimit;
+    }
+
+    /**
+     * Deposit {tokenAddress} token via transferFrom. Then records the amount in local structs.
+     * You cannot participate twice in the same round, for the sake of simplicity. An approve
+     * must occur beforehand for at least {tokenAmount}.
+     */
+    function deposit(uint256 tokenAmount) public payable {
+        require(msg.value >= getDepositTax(), "Insuffitient tax");
+        require(rounds[currentRoundId].balances[msg.sender] == 0, "You already entered this round, wait for the next one");
+        require(tokenAmount > 0, "Amount should be greater than zero");
+
+        IERC20(tokenAddress).safeTransferFrom(msg.sender, address(this), tokenAmount);
+
+        rounds[currentRoundId].participants.push(msg.sender);
+        rounds[currentRoundId].balances[msg.sender] = tokenAmount;
+
+        emit DepositTaxPaid(msg.sender, msg.value);
+        emit UserDeposit(msg.sender, tokenAmount, currentRoundId);
+    }
+
+    /**
+     * Same as deposit, but for someone else
+     */
+    function depositTo(address _recipient, uint256 tokenAmount) public payable {
+        require(msg.value >= getDepositTax(), "Insuffitient tax");
+        require(rounds[currentRoundId].balances[_recipient] == 0, "You already entered this round, wait for the next one");
+        require(tokenAmount > 0, "Amount should be greater than zero");
+
+        IERC20(tokenAddress).safeTransferFrom(msg.sender, address(this), tokenAmount);
+
+        rounds[currentRoundId].participants.push(_recipient);
+        rounds[currentRoundId].balances[_recipient] = tokenAmount;
+
+        emit DepositTaxPaid(_recipient, msg.value);
+        emit UserDeposit(_recipient, tokenAmount, currentRoundId);
+    }
+
+    /**
+     * Anyone can call this function to end the current round and bridge the tokens in the contract.
+     * The caller gets all native token present in the contract, collected through the collective
+     * {depositTax} that each participant gave over time. Blocks the contract until the message
+     * of sucess arrives from the destination chain.
+     */
+    function bridge() public returns (bytes32 messageId, uint256 fees) {
+        require(rounds[currentRoundId].participants.length > 0, "No participants yet");
+        // require(address(this).balance >= getLastDestinationChainFees(), "Not enough gas to call ccip");
+
+        // Bridge tokens with current Round data
+        (messageId, fees) = _bridgeBalances();
+
+        // Pay rewards to protocol and caller
+        _payRewards();
+        
+        currentRoundId += 1;
+
+        FullRound storage newRound = rounds.push();
+        newRound.roundId = 0;
+        newRound.participants = new address[](0);
+
+        return (messageId, fees);
+    }
+
+    /**
+     * Sends the {tokenAddress} and {currentRound} Round to destination chain via CCIP.
+     * Returns messageId for tracking purposes.
+     */
+    function _bridgeBalances() internal returns (bytes32 messageId, uint256 fees) {
+        (SimpleRound memory currentRound, uint256 currentTokenAmount) = _getCurrentSimpleRoundAndTokenAmount();
+        // require(IERC20(tokenAddress).balanceOf(address(this)) >= currentTokenAmount, "Corrupted contract");
+
+        Client.EVMTokenAmount memory tokenAmount =
+            Client.EVMTokenAmount({token: address(tokenAddress), amount: currentTokenAmount});
+        Client.EVMTokenAmount[] memory tokenAmounts = new Client.EVMTokenAmount[](1);
+        tokenAmounts[0] = tokenAmount;
+
+        IRouterClient router = IRouterClient(localRouter);
+
+        Client.EVM2AnyMessage memory message = Client.EVM2AnyMessage({
+            receiver: abi.encode(destinationContract),
+            data: abi.encode(currentRound),
+            tokenAmounts: tokenAmounts,
+            extraArgs: Client._argsToBytes(Client.EVMExtraArgsV1({gasLimit: destinationGasLimit, strict: false})),
+            feeToken: address(0) // Pay in native
+        });
+
+        fees = router.getFee(destinationChainSelector, message);
+        messageId = router.ccipSend{value: fees}(destinationChainSelector, message);
+
+        emit RoundBridged(currentRoundId, currentRound.participants, currentRound.balances, currentTokenAmount, fees, messageId);
+    }
+
+    /**
+     * Getters
+     */
+
+    function getTokenAddress() external view returns (address) {
+        return tokenAddress;
+    }
+
+    function getDestinationChainSelector() external view returns (uint64) {
+        return destinationChainSelector;
+    }
+
+    function getDestinationContract() external view returns (address) {
+        return destinationContract;
+    }
+
+    function getCurrentRoundId() external view returns (uint256) {
+        return currentRoundId;
+    }
+
+    function getBalancesAsArray() public view returns (uint256[] memory balancesArray) {
+        balancesArray = new uint256[](rounds[currentRoundId].participants.length);
+
+        for (uint256 i = 0; i < rounds[currentRoundId].participants.length;) {
+            balancesArray[i] = rounds[currentRoundId].balances[rounds[currentRoundId].participants[i]];
+            unchecked {
+                i++;
+            }
+        }
+    }
+
+    function getCurrentTokenAmount() public view returns (uint256 currentTokenAmount) {
+        currentTokenAmount = 0;
+
+        for (uint256 i = 0; i < rounds[currentRoundId].participants.length;) {
+            currentTokenAmount += rounds[currentRoundId].balances[rounds[currentRoundId].participants[i]];
+            unchecked {
+                i++;
+            }
+        }
+    }
+
+    function getBalances(address user) public view returns (uint256) {
+        return rounds[currentRoundId].balances[user];
+    }
+
+    function getCurrentRound() public view returns (SimpleRound memory currentRound) {
+        uint256[] memory balancesArray = getBalancesAsArray();
+
+        currentRound = SimpleRound({roundId: currentRoundId, balances: balancesArray, participants: rounds[currentRoundId].participants});
+    }
+
+    function _getCurrentSimpleRoundAndTokenAmount()
+        internal
+        view
+        returns (SimpleRound memory currentRound, uint256 currentTokenAmount)
+    {
+        currentTokenAmount = 0;
+        uint256[] memory balancesArray = new uint256[](rounds[currentRoundId].participants.length);
+        uint256 participantBalance = 0;
+
+        for (uint16 i = 0; i < rounds[currentRoundId].participants.length;) {
+            participantBalance = rounds[currentRoundId].balances[rounds[currentRoundId].participants[i]];
+            currentTokenAmount += participantBalance;
+            balancesArray[i] = participantBalance;
+            unchecked {
+                i++;
+            }
+        }
+
+        currentRound = SimpleRound({roundId: currentRoundId, balances: balancesArray, participants: rounds[currentRoundId].participants});
+    }
+
+    function isRoundSuccessful(uint256 roundId) external view returns (bool) {
+        return roundId < currentRoundId;
+    }
+
+    function getContractTokenBalance() external view returns (uint256) {
+        return IERC20(tokenAddress).balanceOf(address(this));
+    }
+}

--- a/src/interfaces/OptimisticCCCB/IOptimisticCCCB.sol
+++ b/src/interfaces/OptimisticCCCB/IOptimisticCCCB.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache License 2.0
+pragma solidity 0.8.20;
+
+interface IOptimisticCCCB {
+    struct Round {
+        address[] participants;
+        mapping(address => uint256) balances;
+    }
+
+    struct FullRound {
+        uint256 roundId;
+        address[] participants;
+        mapping(address => uint256) balances;
+    }
+
+    struct SimpleRound {
+        uint256 roundId;
+        address[] participants;
+        uint256[] balances;
+    }
+}

--- a/src/interfaces/OptimisticCCCB/ISourceChainOptimisticCCCB.sol
+++ b/src/interfaces/OptimisticCCCB/ISourceChainOptimisticCCCB.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache License 2.0
+pragma solidity 0.8.20;
+
+import {IOptimisticCCCB} from "./IOptimisticCCCB.sol";
+
+interface ISourceChainOptimisticCCCB is IOptimisticCCCB {
+    event UserDeposit(address _sender, uint256 _amount, uint256 roundId);
+    event DepositTaxPaid(address _sender, uint256 _amount);
+    event RoundBridged(uint256 roundId, address[] _participants, uint256[] _balances, uint256 _tokenAmount, uint256 _destinationFees, bytes32 _ccipMessageId);
+}

--- a/test/OptimisticCCCB/SourceChainOptimisticCCCB.test.sol
+++ b/test/OptimisticCCCB/SourceChainOptimisticCCCB.test.sol
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache License 2.0
+pragma solidity 0.8.20;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {Test, console} from "forge-std/Test.sol";
+import {SourceChainOptimisticCCCB} from "../../src/OptimisticCCCB/SourceChainOptimisticCCCB.sol";
+import {Utils} from "../utils/Utils.sol";
+import {Client} from "@chainlink/contracts-ccip/src/v0.8/ccip/libraries/Client.sol";
+
+contract SourceChainOptimisticCCCBTest is Test, Utils {
+    SourceChainOptimisticCCCB public bridge;
+    address alice = vm.addr(0xa11ce0000000dead);
+    address bob = vm.addr(0xb0b0000000dead);
+    address manager = vm.addr(0x81273);
+
+    function setUp() public {
+        vm.createSelectFork("ethereumSepolia");
+        bridge = new SourceChainOptimisticCCCB(
+            routerEthereumSepolia, chainIdAvalancheFuji, chainIdEthereumSepolia, manager, ccipBnMEthereumSepolia, routerEthereumSepolia
+        );
+        vm.startPrank(manager);
+        // bridge.setTokenAddress(ccipBnMEthereumSepolia);
+        bridge.setDestinationContract(address(alice));
+        vm.stopPrank();
+
+        vm.label(routerEthereumSepolia, "Router sepolia");
+        vm.label(ccipBnMEthereumSepolia, "BnM token");
+        vm.label(linkEthereumSepolia, "LINK Sepolia");
+    }
+
+    // /**
+    //  * One deposit cost 83_669 gas for 1 user [safeTransferFrom + push in array + write in mapping]
+    //  * One brige for 1 user costs 303_600. But for 100 users it costs
+    //  */
+    // function test_deposit_and_bridge() public {
+    //     uint256 despoitTax = bridge.getDepositTax();
+    //     uint256 tokenAmount = 10e18;
+    //     deal(alice, despoitTax);
+    //     deal(ccipBnMEthereumSepolia, alice, tokenAmount);
+
+    //     vm.startPrank(alice);
+    //     IERC20(ccipBnMEthereumSepolia).approve(address(bridge), tokenAmount);
+    //     bridge.deposit{value: despoitTax}(tokenAmount);
+    //     vm.stopPrank();
+
+    //     assertEq(IERC20(ccipBnMEthereumSepolia).balanceOf(address(bridge)), tokenAmount);
+    //     assertEq(IERC20(ccipBnMEthereumSepolia).balanceOf(alice), 0);
+    //     assertEq(alice.balance, 0); // Use all tax
+
+    //     (uint256 protocolReward, uint256 callerReward) = bridge.getEstimatedRewards();
+    //     uint256 previousBobBalance = bob.balance;
+
+    //     deal(address(bridge), 500_000_000_000_000_000); // Give some eth to be able to call destination chain
+        
+    //     vm.startPrank(bob);
+    //     bridge.bridge();
+    //     bridge.claimRewards(); // Not enough for rewards
+    //     vm.stopPrank();
+
+    //     vm.prank(bridge.owner());
+    //     bridge.claimProtocolRewards();
+
+    //     if (protocolReward == 0) {
+    //         assertEq(address(bridge.owner()).balance, 0);
+    //     } else {
+    //         assertGe(address(bridge.owner()).balance, (85 * protocolReward) / 100);
+    //     }
+
+    //     if (callerReward == 0) {
+    //         assertEq(bob.balance - previousBobBalance, 0);
+    //     } else {
+    //         assertGe(bob.balance - previousBobBalance, (85 * callerReward) / 100);
+    //     }
+
+    //     assertEq(IERC20(ccipBnMEthereumSepolia).balanceOf(address(bridge)), 0);
+    // }
+
+    /**
+     * forge-config: default.fuzz.runs = 2
+     * forge-config: default.fuzz.max-test-rejects = 0
+     */
+    function test_collectiveDeposit() public {
+        // vm.assume(n_users > 5);
+        uint16 n_users = 100;
+        uint256 initialContractbalance = address(bridge).balance;
+
+        uint256 tokenAmount = 10e18;
+        uint256 tax = bridge.getDepositTax();
+
+        for (uint256 i = 0; i < n_users; i++) {
+            address user = vm.addr(100 + i);
+
+            deal(user, tax);
+            deal(ccipBnMEthereumSepolia, user, tokenAmount);
+
+            vm.startPrank(user);
+            IERC20(ccipBnMEthereumSepolia).approve(address(bridge), tokenAmount);
+            bridge.deposit{value: tax}(tokenAmount);
+            vm.stopPrank();
+        }
+
+        assertEq(IERC20(ccipBnMEthereumSepolia).balanceOf(address(bridge)), n_users * tokenAmount);
+        assertEq(address(bridge).balance, initialContractbalance + (n_users * tax));
+
+        uint256 previousOwnerBalance = address(bridge.owner()).balance;
+        uint256 previousBobBalance = bob.balance;
+        uint256 previousContractbalance = address(bridge).balance;
+        (uint256 protocolReward, uint256 callerReward) = bridge.getEstimatedRewards();
+
+        if (previousContractbalance > bridge.getDestinationChainFees()) {
+            assertEq(previousContractbalance - bridge.getDestinationChainFees(), protocolReward + callerReward);
+        }
+
+        vm.startPrank(bob);
+        bridge.bridge();
+        bridge.claimRewards();
+        vm.stopPrank();
+
+        vm.prank(bridge.owner());
+        bridge.claimProtocolRewards();
+
+        if (protocolReward == 0) {
+            assertEq(address(bridge.owner()).balance - previousOwnerBalance, 0);
+        } else {
+            assertGe(address(bridge.owner()).balance - previousOwnerBalance, (85 * protocolReward) / 100);
+        }
+
+        if (callerReward == 0) {
+            assertEq(bob.balance - previousBobBalance, 0);
+        } else {
+            assertGe(bob.balance - previousBobBalance, (85 * callerReward) / 100); // Be flexible a bit
+        }
+
+        assertGe(address(bridge).balance, bridge.getDestinationChainFees()); // Save for next call
+        assertEq(IERC20(ccipBnMEthereumSepolia).balanceOf(address(bridge)), 0);
+    }
+}


### PR DESCRIPTION
- Users do not have to wait for the previous round to end to deposit tokens.
- This version does not manage `ContractState`
- It sends one message to the destination chain, and in the ccipReceive on destination, it distributes the funds right away. There is no need to lock the contracts
- If a message gets stuck, a retry is all needed
- It uses a global struct array of `FullRound`. The minimum data to save per user is its address and balance, so we use a mapping and an array, as a way to store the mapping keys.
- `EnumerableMapping` from OpenZepellin would have been useful here, but it uses one extra mapping we don't need. They use it to check whether an address is part of the array in O(1), but we can simply check that if the deposited balance is different from zero.
- Each user can only deposit ONCE per round. It is not possible to add in the same round with the current architecture
- The gas cost is 20% higher than the previous version
- A user can deposit for someone else

TODO

- Destination Chain Optimistic CCCB contract
- Destination Chain Optimistic CCCB tests
- Source Chain Optimistic CCCB test [more]
- Use custom errors instead of hardcoded message errors